### PR TITLE
fix: correct import path for getRandomItem utility

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -15,7 +15,7 @@ import {
   INITIAL_DELAY,
   NO_KILL_PHRASES,
 } from "./constants";
-import { getRandomItem } from "@utils";
+import { getRandomItem } from "./utils";
 import Lobby from "./lobby";
 import Player from "./entity/player";
 import { serverSocket } from "./app";


### PR DESCRIPTION
## Summary

- correct import path for getRandomItem utility

## Critical changes

List any dependencies that are required for this change, or leave `-`

## Issue ticket code (and/or) link:

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of on my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have runned `npm run build` without errors
