### PR TITLE
fix: atomic player stats and resilient login (P1)

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -7,26 +7,36 @@ import { CustomError } from "@types";
 import { connection } from "../db";
 
 export async function login(req: Request, res: Response) {
-  const { email, picture } = req.body;
-  const transformedURL = await transformUrl(picture);
-  const uploadResult = await cloudinary.uploader.upload(transformedURL, {
-    folder: "users",
-    format: "png",
-  });
-  const pictureUrl = uploadResult.secure_url;
-  await connection();
   try {
+    const { email, picture } = req.body;
+    // Cloudinary upload and DB connect run inside the try block — previously they
+    // ran before it, so a failed upload/connect escaped the handler as an
+    // unhandled rejection and the request hung with no response.
+    const transformedURL = transformUrl(picture);
+    const uploadResult = await cloudinary.uploader.upload(transformedURL, {
+      folder: "users",
+      format: "png",
+    });
+    const pictureUrl = uploadResult.secure_url;
+    await connection();
+
     const user = await User.findOne({ email });
     if (user) {
-      const publicId = user.picture.split("/").pop()?.split(".")[0]; // Extract public ID
-      await cloudinary.uploader.destroy(`users/${publicId}`);
+      const publicId = user.picture?.split("/").pop()?.split(".")[0]; // Extract public ID
+      if (publicId) {
+        await cloudinary.uploader.destroy(`users/${publicId}`);
+      }
 
-      await User.findOneAndUpdate({ email }, { picture: pictureUrl });
+      const updatedUser = await User.findOneAndUpdate(
+        { email },
+        { picture: pictureUrl },
+        { new: true },
+      );
       res.json({
         status: "success",
         code: 200,
         data: {
-          user,
+          user: updatedUser,
         },
       });
       return;

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -41,29 +41,24 @@ export const updatePlayerStats = async ({
 }: updatePlayerArgs) => {
   await connection();
   try {
-    const playerStats = await PlayStats.findOne({ userId });
-    if (playerStats) {
-      await PlayStats.findOneAndUpdate(
-        { userId },
-        {
-          $inc: { games: 1, points, kills },
-          $set: {
-            wins: isWin ? playerStats.wins + 1 : playerStats.wins,
-            top3: isTop3 ? playerStats.top3 + 1 : playerStats.top3,
-          },
+    const user = await User.findOne({ socketID: userId });
+    // Single atomic upsert: read-then-write was racy (lost wins/top3 updates and
+    // duplicate-key errors when two game-ends for the same user interleaved).
+    // $inc handles both create and update; userName is only set on insert.
+    await PlayStats.findOneAndUpdate(
+      { userId },
+      {
+        $inc: {
+          games: 1,
+          points,
+          kills,
+          wins: isWin ? 1 : 0,
+          top3: isTop3 ? 1 : 0,
         },
-      );
-    } else {
-      const user = await User.findOne({ socketID: userId });
-      await PlayStats.create({
-        userId,
-        userName: user.name,
-        points,
-        kills,
-        wins: isWin,
-        games: 1,
-      });
-    }
+        $setOnInsert: { userName: user?.name ?? "Unknown" },
+      },
+      { upsert: true, new: true },
+    );
   } catch (error: unknown) {
     if (error instanceof Error) {
       console.error(error.message);


### PR DESCRIPTION
## Summary
P1 data-integrity and robustness fixes. **Stacked on the P0 branch** (`fix/interval-leak-and-connection-stability`); base will retarget to `dev` once P0 merges.

## Changes
**Atomic stats (`services/stats.ts`)**
- `updatePlayerStats` used a read-then-write (`findOne` then `findOneAndUpdate`/`create`) that lost win/top3 increments and could hit duplicate-key errors when two game-ends for the same user interleaved. Replaced with a single atomic `findOneAndUpdate(..., { $inc }, { upsert: true })`. Also fixes a first-game `top3` being dropped, a boolean written into the numeric `wins` field, and an unguarded `user.name` that could throw and silently discard a whole game's stats.

**Resilient login (`controllers/auth.ts`)**
- Cloudinary upload and DB connect now run inside the `try/catch` (they previously ran before it, so a failed upload/connect escaped the handler and the request hung with no response). The existing-user branch returns the updated document instead of the stale one, and the avatar `publicId` split is guarded against a missing picture.

## Not included (recommended as a dedicated follow-up)
- Comprehensive socket-payload validation (every gameplay event is currently consumed unvalidated).
- Real auth token verification for `/auth` (currently trusts the posted email).
These are feature-sized hardening tasks better done with focused review.

## Verification
- `tsc` typecheck + build pass. Requires in-DEV verification.