### PR TITLE
Promote to PROD

### DIFF
--- a/.claude/rules/commit-conventions.md
+++ b/.claude/rules/commit-conventions.md
@@ -1,0 +1,23 @@
+# Commit Conventions
+
+## Creating Commits
+
+Use the `/commit` command to create commits. It will:
+1. Analyze staged and unstaged changes
+2. Review recent commits to infer the repository's commit style
+3. Create a commit following the existing convention
+
+## Usage
+
+```
+/commit
+```
+
+The command automatically stages relevant changes and creates a commit message that matches the repository's style.
+
+## Manual Commits
+
+If committing manually, follow the existing commit message style in the repository by reviewing recent commits:
+```bash
+git log --oneline -10
+```

--- a/.claude/rules/pr-conventions.md
+++ b/.claude/rules/pr-conventions.md
@@ -1,0 +1,17 @@
+# Pull Request Conventions
+
+## PR Descriptions
+
+When creating pull requests, write the title and body as if authored by the developer.
+
+**Do NOT include any AI/assistant attribution or mentions**, such as:
+- "Created by Claude" / "Generated with Claude Code"
+- "🤖 Generated with ..." footers
+- "Co-Authored-By: Claude ..." trailers
+- Any other reference to Claude, Anthropic, or an AI assistant
+
+## Content
+
+- Summarize *what* changed and *why*, focused on the code and the problem it solves.
+- Follow the existing style of recent PRs in the repository where one exists.
+- Keep it concise and reviewer-oriented; link related issues where applicable.

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,22 @@ const start = async () => {
     });
 
     serverSocket.sockets.on("connection", (client: CustomSocket) => {
-      //update user socket id
+      // Identity is provided in the handshake, so it is known synchronously here
+      // — before any lobby/gameplay event handler can run. This removes the race
+      // where a player joined a game or acted before "updateUserSocketId" was
+      // processed, and re-establishes identity on every reconnect.
+      const handshakeAuth = client.handshake.auth as {
+        socketId?: string;
+        email?: string;
+      };
+      if (handshakeAuth.socketId) {
+        client.customId = handshakeAuth.socketId;
+        if (handshakeAuth.email) {
+          storeSocketID(handshakeAuth.email, handshakeAuth.socketId);
+        }
+      }
+
+      //update user socket id (covers users who log in mid-session)
       client.on("updateUserSocketId", async req => {
         await storeSocketID(req.email, req.socket_id);
 
@@ -138,6 +153,11 @@ const start = async () => {
     });
 
     function onClientDisconnect(client: CustomSocket) {
+      // Always release the per-connection bomb-queue interval, even for sockets
+      // that only visited the lobby and never joined a game — otherwise every
+      // connection leaks a 100ms timer.
+      client.playInstance?.destroy();
+
       if (client.socket_game_id == null) {
         return;
       }

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -7,26 +7,36 @@ import { CustomError } from "@types";
 import { connection } from "../db";
 
 export async function login(req: Request, res: Response) {
-  const { email, picture } = req.body;
-  const transformedURL = await transformUrl(picture);
-  const uploadResult = await cloudinary.uploader.upload(transformedURL, {
-    folder: "users",
-    format: "png",
-  });
-  const pictureUrl = uploadResult.secure_url;
-  await connection();
   try {
+    const { email, picture } = req.body;
+    // Cloudinary upload and DB connect run inside the try block — previously they
+    // ran before it, so a failed upload/connect escaped the handler as an
+    // unhandled rejection and the request hung with no response.
+    const transformedURL = transformUrl(picture);
+    const uploadResult = await cloudinary.uploader.upload(transformedURL, {
+      folder: "users",
+      format: "png",
+    });
+    const pictureUrl = uploadResult.secure_url;
+    await connection();
+
     const user = await User.findOne({ email });
     if (user) {
-      const publicId = user.picture.split("/").pop()?.split(".")[0]; // Extract public ID
-      await cloudinary.uploader.destroy(`users/${publicId}`);
+      const publicId = user.picture?.split("/").pop()?.split(".")[0]; // Extract public ID
+      if (publicId) {
+        await cloudinary.uploader.destroy(`users/${publicId}`);
+      }
 
-      await User.findOneAndUpdate({ email }, { picture: pictureUrl });
+      const updatedUser = await User.findOneAndUpdate(
+        { email },
+        { picture: pictureUrl },
+        { new: true },
+      );
       res.json({
         status: "success",
         code: 200,
         data: {
-          user,
+          user: updatedUser,
         },
       });
       return;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -7,17 +7,23 @@ dotenv.config();
 const contactsDB = process.env.DB_HOST ?? "";
 
 const connection = async () => {
-  try {
-    mongoose.set("strictQuery", false);
-    await mongoose.connect(contactsDB);
-    console.log("MongoDB Connected...");
-  } catch (err: unknown) {
-    if (err instanceof Error) {
-      console.error(err.message);
-    }
-    // Terminate the process with a failure code
-    process.exit(1);
+  // Reuse the pooled connection. connect() is invoked from per-request and
+  // per-socket paths; without this guard every call re-entered mongoose.connect
+  // and a transient DB error called process.exit(1), killing the whole server
+  // (and every connected player) mid-game. Connect once, then short-circuit.
+  // readyState: 1 = connected, 2 = connecting.
+  if (
+    mongoose.connection.readyState === 1 ||
+    mongoose.connection.readyState === 2
+  ) {
+    return;
   }
+
+  mongoose.set("strictQuery", false);
+  // Let errors propagate to the caller. At boot, app.ts's start() catch logs
+  // and exits; per-request callers handle/log without taking down the server.
+  await mongoose.connect(contactsDB);
+  console.log("MongoDB Connected...");
 };
 
 export default connection;

--- a/src/play.ts
+++ b/src/play.ts
@@ -83,6 +83,16 @@ class Play {
     }, 100);
   }
 
+  // Release the per-connection bomb-queue interval. Must be called when the
+  // socket disconnects, otherwise every connection leaks a 100ms timer forever.
+  destroy() {
+    if (this.bombQueueInterval) {
+      clearInterval(this.bombQueueInterval);
+      this.bombQueueInterval = null;
+    }
+    this.bombQueue.clear();
+  }
+
   onLeaveGame() {
     if (this.socket_game_id) {
       // Clear bomb queue for this game

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -41,29 +41,24 @@ export const updatePlayerStats = async ({
 }: updatePlayerArgs) => {
   await connection();
   try {
-    const playerStats = await PlayStats.findOne({ userId });
-    if (playerStats) {
-      await PlayStats.findOneAndUpdate(
-        { userId },
-        {
-          $inc: { games: 1, points, kills },
-          $set: {
-            wins: isWin ? playerStats.wins + 1 : playerStats.wins,
-            top3: isTop3 ? playerStats.top3 + 1 : playerStats.top3,
-          },
+    const user = await User.findOne({ socketID: userId });
+    // Single atomic upsert: read-then-write was racy (lost wins/top3 updates and
+    // duplicate-key errors when two game-ends for the same user interleaved).
+    // $inc handles both create and update; userName is only set on insert.
+    await PlayStats.findOneAndUpdate(
+      { userId },
+      {
+        $inc: {
+          games: 1,
+          points,
+          kills,
+          wins: isWin ? 1 : 0,
+          top3: isTop3 ? 1 : 0,
         },
-      );
-    } else {
-      const user = await User.findOne({ socketID: userId });
-      await PlayStats.create({
-        userId,
-        userName: user.name,
-        points,
-        kills,
-        wins: isWin,
-        games: 1,
-      });
-    }
+        $setOnInsert: { userName: user?.name ?? "Unknown" },
+      },
+      { upsert: true, new: true },
+    );
   } catch (error: unknown) {
     if (error instanceof Error) {
       console.error(error.message);


### PR DESCRIPTION
connection() called mongoose.connect() on every request/socket operation and
ran process.exit(1) on any error, so a transient DB blip could kill the whole
server mid-game. Guard on connection state to connect once and reuse the pool,
and let errors propagate (boot failures still exit via start()'s catch).## Summary

Please include a summary of the changes as a bullet list.

## Critical changes

List any dependencies that are required for this change, or leave `-`

## Issue ticket code (and/or) link:

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of on my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have runned `npm run build` without errors
