### PR TITLE
Promote to PROD

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -67,9 +67,15 @@ const start = async () => {
       const handshakeAuth = client.handshake.auth as {
         socketId?: string;
         email?: string;
+        name?: string;
+        picture?: string;
       };
       if (handshakeAuth.socketId) {
         client.customId = handshakeAuth.socketId;
+        // Keep the client's profile on the socket so players render correctly
+        // without depending on a DB lookup at join time.
+        client.userName = handshakeAuth.name;
+        client.userPicture = handshakeAuth.picture;
         if (handshakeAuth.email) {
           storeSocketID(handshakeAuth.email, handshakeAuth.socketId);
         }
@@ -80,6 +86,12 @@ const start = async () => {
         await storeSocketID(req.email, req.socket_id);
 
         client.customId = req.socket_id;
+        if (req.name) {
+          client.userName = req.name;
+        }
+        if (req.picture) {
+          client.userPicture = req.picture;
+        }
       });
 
       // Create a new Play instance and store it on the client object

--- a/src/entity/game.ts
+++ b/src/entity/game.ts
@@ -68,11 +68,21 @@ export class Game {
     this.createdAt = Date.now();
   }
 
-  async addPlayer(id: string) {
-    const user = await this.getUserInfo(id);
+  async addPlayer(id: string, profile?: { name?: string; picture?: string }) {
+    // Prefer the profile the client supplied in its handshake — rendering then
+    // does not depend on a DB lookup that can race with identity storage or be
+    // clobbered when the same account is used in two sessions. Fall back to the
+    // DB only when the client did not provide a profile.
+    let name = profile?.name;
+    let skin = profile?.picture;
+    if (!name || !skin) {
+      const user = await this.getUserInfo(id);
+      name = name || user?.name;
+      skin = skin || user?.picture;
+    }
 
     const existPlayer = this.players.find(
-      player => player.name === user?.name && player.skin === user?.picture,
+      player => player.name === name && player.skin === skin,
     );
 
     if (existPlayer) {
@@ -83,8 +93,8 @@ export class Game {
     const [spawn, spawnOnGrid] = this.getAndRemoveSpawn();
     const player = new Player({
       id,
-      skin: user?.picture || "",
-      name: user?.name || "",
+      skin: skin || "",
+      name: name || "",
       spawn,
       spawnOnGrid,
     });

--- a/src/lobby.ts
+++ b/src/lobby.ts
@@ -25,7 +25,7 @@ const Lobby = {
   onCreateGame(
     this: CustomSocket,
     data: NewGamePayload,
-    callback: (data: { game_id: string }) => void
+    callback: (data: { game_id: string }) => void,
   ) {
     const newGame = Lobby.createPendingGame(data);
     newGame.createdAt = Date.now(); // Store timestamp
@@ -44,7 +44,10 @@ const Lobby = {
 
       // Save current game ID in the socket object
       this.socket_game_id = current_game.id;
-      await current_game.addPlayer(this.customId || "");
+      await current_game.addPlayer(this.customId || "", {
+        name: this.userName,
+        picture: this.userPicture,
+      });
 
       if (current_game.isFull()) {
         Lobby.updateLobbyGames();
@@ -94,14 +97,14 @@ const Lobby = {
   },
 
   availablePendingGames() {
-    return Array.from(pendingGames.values()).filter((game) => !game.isFull());
+    return Array.from(pendingGames.values()).filter(game => !game.isFull());
   },
 
   onCheckNameAvailable(
     gameName: string,
-    callback: (data: { isAvailable: boolean }) => void
+    callback: (data: { isAvailable: boolean }) => void,
   ) {
-    const isAvailable = !Array.from(pendingGames.values()).some((game) => {
+    const isAvailable = !Array.from(pendingGames.values()).some(game => {
       return game.name === gameName;
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export type Player = {
 
 export interface CustomSocket extends Socket {
   customId?: string;
+  userName?: string;
+  userPicture?: string;
   playInstance?: Play;
   socket_game_id?: string | null;
 }


### PR DESCRIPTION
Players were added with name/skin resolved via getUserBySocketId, which returns
null when the User's socketID has been clobbered by another session of the same
account or when identity storage hasn't completed — leaving the player with an
empty name and a missing (black) avatar texture for everyone. Carry the name and
picture in the handshake auth (and the updateUserSocketId event), store them on
the socket, and use them directly in addPlayer, falling back to the DB lookup.## Summary

Please include a summary of the changes as a bullet list.

## Critical changes

List any dependencies that are required for this change, or leave `-`

## Issue ticket code (and/or) link:

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of on my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have runned `npm run build` without errors
