### PR TITLE
fix: /auth silently fails to create users (no avatar in DB)

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -9,15 +9,11 @@ import { connection } from "../db";
 export async function login(req: Request, res: Response) {
   try {
     const { email, picture } = req.body;
-    // Cloudinary upload and DB connect run inside the try block — previously they
-    // ran before it, so a failed upload/connect escaped the handler as an
-    // unhandled rejection and the request hung with no response.
-    const transformedURL = transformUrl(picture);
-    const uploadResult = await cloudinary.uploader.upload(transformedURL, {
-      folder: "users",
-      format: "png",
-    });
-    const pictureUrl = uploadResult.secure_url;
+    // Avatar handling must never block account creation. Throwaway/incognito
+    // Google accounts can have no profile photo (empty picture), and Cloudinary
+    // can fail — in both cases fall back to the source URL (or empty) instead of
+    // failing the whole request, which previously left the user uncreated.
+    const pictureUrl = await uploadAvatar(picture);
     await connection();
 
     const user = await User.findOne({ email });
@@ -61,6 +57,28 @@ export async function login(req: Request, res: Response) {
         .status(500)
         .json({ success: false, message: "An unknown error occurred" });
     }
+  }
+}
+
+// Upload the avatar to Cloudinary, returning the hosted URL. Never throws —
+// returns the source URL (or empty string) if there is no picture or the upload
+// fails, so a missing/broken avatar cannot block account creation.
+async function uploadAvatar(picture?: string): Promise<string> {
+  if (!picture) {
+    return "";
+  }
+  try {
+    const uploadResult = await cloudinary.uploader.upload(
+      transformUrl(picture),
+      {
+        folder: "users",
+        format: "png",
+      },
+    );
+    return uploadResult.secure_url;
+  } catch (error) {
+    console.error("Cloudinary upload failed, using source URL:", error);
+    return picture;
   }
 }
 

--- a/src/middlewares/validation/schemas.ts
+++ b/src/middlewares/validation/schemas.ts
@@ -2,10 +2,13 @@ import Joi, { ObjectSchema } from "joi";
 
 const userSchema = Joi.object({
   name: Joi.string().trim(true).required(),
-  email: Joi.string().trim(true).required(),
-  socketID: Joi.string(),
-  locale: Joi.string(),
-  picture: Joi.string(),
+  email: Joi.string().trim(true).email().required(),
+  // These are optional and may legitimately be empty/absent (e.g. a Google
+  // account with no profile photo, or before the socket id is assigned).
+  // Rejecting them previously made /auth return 422 and silently failed signup.
+  socketID: Joi.string().allow(null, ""),
+  locale: Joi.string().allow(null, ""),
+  picture: Joi.string().allow(null, ""),
 });
 
 export default {


### PR DESCRIPTION
## Summary
A newly-logged-in player (e.g. `bladeruuner5071@gmail.com`) never appeared in the `users` collection, so they rendered with no avatar/nickname. Root cause: `/auth` rejected the signup with 422 and the client's `addUser` swallowed the error.

## Confirmed failure modes (reproduced against the Joi schema)
- `socketID: null` (localStorage blocked or set after the request) → 422
- `picture: ""` (Google account with **no profile photo**) → 422, and would also throw in the Cloudinary upload
- `name: ""` / invalid email → 422 (these we *want* to reject)

All silent because `addUser` catches and discards non-OK responses. This is pre-existing (no new user has been created since ~May 2025) and unrelated to the recent socket fixes.

## Fix
- Schema: `socketID`, `locale`, `picture` are now optional and may be `null`/empty; `email` is validated as an email. `name`/`email` stay required.
- Controller: avatar handling never blocks creation — skip Cloudinary when there is no picture, and fall back to the source URL if the upload fails.

Frontend follow-up (separate PR) surfaces `addUser` errors and guarantees a non-empty name.

## Verification
- Schema reproduced rejecting then accepting the payloads; `tsc` + build pass. Needs in-DEV retry with the throwaway account.