### PR TITLE
chore: trim unused CORS origins

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,18 +16,12 @@ import Lobby from "./lobby";
 import Play from "./play";
 import router from "./routes/index";
 
-// Allow every origin the app is served from. dev and main previously carried
-// different, mutually-exclusive allowlists, so a frontend hosted on one domain
-// was blocked when it called a backend built from the other branch. Keep a
-// single inclusive list of all known frontend origins.
+// Frontend origins allowed to call the API.
 const corsOptions = {
   origin: [
     "http://localhost:3000",
     "https://bomberman-2-0.vercel.app",
     "https://bomberman-2-0-dev.vercel.app",
-    "https://bomberman.click",
-    "https://www.bomberman.click",
-    "https://dev.bomberman.click",
   ],
   optionsSuccessStatus: 200,
 };


### PR DESCRIPTION
Remove the unused bomberman.click / www.bomberman.click / dev.bomberman.click origins from the CORS allowlist; keep localhost and the Vercel frontends.