### PR TITLE
ci: sync deploy to origin/main and fail fast

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,17 +20,29 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            # Husky's prepare script is for local dev hooks; skip it in CI.
+            export HUSKY=0
+
             echo "Loading NVM..."
             export NVM_DIR="$HOME/.nvm"
             source "$NVM_DIR/nvm.sh"
-            nvm use 22.14.0 
+            nvm use 22.14.0
+
+            # Fail the job (and surface a red check) if any step below fails,
+            # instead of silently continuing and reporting success. Enabled
+            # after the nvm sourcing above, which can return nonzero benignly.
+            set -e
 
             cd Bomberman-2.0-Backend
 
-            echo "Resetting repository to avoid conflicts..."
-            git reset --hard HEAD
+            echo "Syncing repository to origin/main..."
+            # Fetch and hard-reset to the REMOTE ref. The previous approach
+            # (reset --hard HEAD + git pull) reset to the droplet's local HEAD
+            # and relied on the pull advancing it; when the pull failed the
+            # droplet stayed frozen on an old commit while CI still went green.
+            git fetch https://${{ secrets.USERNAME }}:${{ secrets.TOKEN }}@github.com/${{ secrets.USERNAME }}/Bomberman-2.0-Backend.git main
+            git reset --hard FETCH_HEAD
             git clean -fd
-            git pull https://${{ secrets.USERNAME }}:${{ secrets.TOKEN }}@github.com/${{ secrets.USERNAME }}/Bomberman-2.0-Backend.git main            
 
             echo "Updating environment variables..."
             cat <<EOF > .env


### PR DESCRIPTION
The deploy step reset to the droplet's local HEAD then relied on `git pull` to advance it. When the pull failed it continued silently (no `set -e`), so the droplet stayed frozen on an old commit while CI reported success — the cause of fixes looking deployed but not actually running. Now fetches and hard-resets to the remote ref, adds `set -e` to fail fast, and skips husky in CI.